### PR TITLE
 [FIX] setDefaultAvatar button of room avatar is not disabled initially even if the avatar is set to default.

### DIFF
--- a/client/components/avatar/RoomAvatarEditor.js
+++ b/client/components/avatar/RoomAvatarEditor.js
@@ -50,7 +50,7 @@ const RoomAvatarEditor = ({ room, roomAvatar, onChangeAvatar = () => {}, ...prop
 						{t('Upload')}
 					</Button>
 
-					<Button primary small danger title={t('Accounts_SetDefaultAvatar')} disabled={roomAvatar === null} onClick={clickReset}>
+					<Button primary small danger title={t('Accounts_SetDefaultAvatar')} disabled={roomAvatar === null || roomAvatar === undefined} onClick={clickReset}>
 						<Icon name='trash' size='x16' />
 					</Button>
 				</ButtonGroup>


### PR DESCRIPTION
On the first load, even if the room avatar is default, the delete/set-default-avatar button is not disabled. It gets disabled on after clicking it once.
This issue is fixed by adding an additional condition in disabled prop of the button.
Since initially, the value of roomAvatar is `undefined`, but in disabled prop the condition is only set if `roomavatar === null`, I have added this additional condition to fix the bug.

## Steps to test or reproduce
Before:
![2022-02-04 18-23-39 (online-video-cutter com)](https://user-images.githubusercontent.com/77449219/152537294-439148c9-e7dc-4d61-974d-68edc3be1a5b.gif)


## Proposed changes (including videos or screenshots)
after:
![2022-02-04 18-30-07 (online-video-cutter com)](https://user-images.githubusercontent.com/77449219/152537353-9fca4d45-e022-433e-88a1-d6e3a43746d0.gif)



## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
